### PR TITLE
chore: rename endpoint to ci/optimizer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ async function requestAndCancelWorkflow({
     repo: { owner, repo }
   } = github.context
 
-  const result = await fetch(`${endpoint}/api/v1/ci`, {
+  const result = await fetch(`${endpoint}/api/v1/ci/optimizer`, {
     method: 'POST',
     body: JSON.stringify({
       token: graphite_token,


### PR DESCRIPTION
Rename endpoint to `ci/optimizer`.

Prefer the more specific name in case we want to make more endpoints in the future.