### PR TITLE
chore: remove unused action input from metadata file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,6 @@ branding:
   color: 'gray-dark'
 
 inputs:
-  github_token:
-    description: 'A GitHub secret to cancel the workflow'
-    required: true
-    default: ''
   graphite_token:
     description: 'Your Graphite CI secret'
     required: true


### PR DESCRIPTION
The `github_token` input defined in the metadata file is not used by the action, but is marked as required. This causes my IDE to think the action is being used incorrectly when it is not supplied, despite not being needed.
<img width="1013" alt="Screenshot 2024-09-21 at 17 08 32" src="https://github.com/user-attachments/assets/657416b6-d788-423f-94d7-fbeef1a59a83">
